### PR TITLE
Use more specific date format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@
 
 # Local Mac: docker container run -it -p 8088:8088 -v /Users/sjaved/projects/personal/ImageMorpher:/app face-morpher-api bash
 
-# Dev Server: (Shell into container then start server)
-# docker container run -it -p 8088:8088 -v /home/sammy/ImageMorpher:/app face-morpher-api bash
-# python manage.py runserver 0:8088 # development server
+# Dev Server: (Shell into container then start dev server)
+#   docker container run -it -p 8088:8088 -v /home/sammy/ImageMorpher:/app face-morpher-api bash
+#   cd imagemorpher;
+#   python manage.py runserver 0:8088
+#
 
 # To update production with latest code changes
 #   SSH into server, enter screen session running docker-compose

--- a/imagemorpher/morph/utils/date.py
+++ b/imagemorpher/morph/utils/date.py
@@ -1,0 +1,16 @@
+import sys
+# morph is essentially the src root directory in this file now
+#   aka import all files with morph/<file-path>
+sys.path.insert(0, '/app/imagemorpher/morph')
+
+import datetime
+import logging
+logging.basicConfig(filename='morph/logs/morph-app-perf.log', level=logging.INFO, format='%(name)s - %(levelname)s - %(message)s')
+
+
+def getMorphDate():
+  morphDate = str(datetime.datetime.now())
+  morphDate = morphDate.replace(" ", "-")
+  morphDate = morphDate.replace(":", "-")
+  morphDate = morphDate.replace(".", "-")
+  return morphDate

--- a/imagemorpher/morph/utils/graphics.py
+++ b/imagemorpher/morph/utils/graphics.py
@@ -20,6 +20,7 @@ import re
 import io
 import uuid
 import datetime
+from utils.date import getMorphDate
 
 from exceptions.CropException import CropException
 
@@ -107,7 +108,7 @@ def getCroppedImagePath(img):
     if (not (isImageTypeSupported(img))):
         raise CropException('File type not supported')
 
-    morphDate = str(datetime.date.today())
+    morphDate = getMorphDate()
     fileHash = uuid.uuid4()
     img_filename = morphDate + '-' + fileHash.hex + '.jpg'
     morphed_img_path = 'morph/content/temp_morphed_images/' + img_filename    # location of saved image

--- a/imagemorpher/morph/utils/image_sources.py
+++ b/imagemorpher/morph/utils/image_sources.py
@@ -1,3 +1,8 @@
+import sys
+# morph is essentially the src root directory in this file now
+#   aka import all files with morph/<file-path>
+sys.path.insert(0, '/app/imagemorpher/morph')
+
 import skimage.io as skio
 import matplotlib.pyplot as plt
 import numpy as np
@@ -7,9 +12,11 @@ import uuid
 import datetime
 import imageio
 
+from utils.date import getMorphDate
+
 def saveImg(morphedImg):
   fileHash = uuid.uuid4()
-  morphDate = str(datetime.date.today())
+  morphDate = getMorphDate()
   img_filename = morphDate + '-' + fileHash.hex + '.jpg'
   morphed_img_path = 'morph/content/temp_morphed_images/' + img_filename    # location of saved image
   imageio.imwrite(morphed_img_path, morphedImg)

--- a/imagemorpher/morph/views.py
+++ b/imagemorpher/morph/views.py
@@ -26,6 +26,7 @@ import sys
 from skimage import img_as_ubyte
 from utils.graphics import getCroppedImagePath, getCroppedImageFromPath
 from utils.image_sources import saveImg
+from utils.date import getMorphDate
 from exceptions.CropException import CropException
 
 # morph is essentially the src root directory in this file now
@@ -67,8 +68,8 @@ def index(request):
         logging.info('request is not valid')
         return HttpResponse('Invalid Request', status=401)
 
-    img1_path = formData['firstImageRef']
-    img2_path = formData['secondImageRef']
+    img1_path = formData['firstImageRef']       # e.g. 2021-07-31-18-46-33-232174-b19ac14523fb4f5fb69dafa86ff97e6f.jpg
+    img2_path = formData['secondImageRef']      #
     img1 = getCroppedImageFromPath(img1_path)
     img2 = getCroppedImageFromPath(img2_path)
 
@@ -104,7 +105,7 @@ def index(request):
             morphed_img_uri_list.append((morphed_img_filename, morphed_im))
         
         fileHash = uuid.uuid4()
-        morphDate = str(datetime.date.today())
+        morphDate = getMorphDate()
         gif_filename = morphDate + '-' + fileHash.hex + '.gif'
         morphed_gif_path = 'morph/content/temp_morphed_images/' + gif_filename    # location of saved image
         morphed_gif_uri = 'https://sammyjaved.com/facemorphs/' + gif_filename     # /facemorphs directory serves static content via nginx


### PR DESCRIPTION
Add seconds/milliseconds to the file timestamp so that when we look through morphed images, we can navigate linearly in time