### PR TITLE
[privacy] Delete user uploaded images upon morph failure/success

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 #   docker container run -it -p 8088:8088 -v /home/sammy/ImageMorpher:/app face-morpher-api bash
 #   cd imagemorpher;
 #   python manage.py runserver 0:8088
-# Then use Postman collection
+# Then use Postman collection to call endpoints
 
 # To update production with latest code changes
 #   SSH into server, enter screen session running docker-compose

--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ Going to try to refactor this code, then maybe try to port it to the web
 * Apply T' to all pixels in target triangle to find the transformed warped triangle
 * Keep doing this for steps in t
 * How does inverse warping work?
+
+# Privacy
+* To delete all images for a certain month we can use the following command.  Note: This deletes all filenames that begin with 2021-11, aka files that were created in november of 2021. 
+`cd /home/sammy/ImageMorpher/imagemorpher/morph/content/temp_morphed_images`
+
+# delete files for a given month
+`find . -type f -name "2021-11*" -delete`
+
+# count number of files
+`find . -type f -name "2022-03*" | wc -l`
+

--- a/imagemorpher/morph/utils/image_sources.py
+++ b/imagemorpher/morph/utils/image_sources.py
@@ -23,6 +23,10 @@ def saveImg(morphedImg):
 
   return img_filename
 
+def deleteImg(filename):
+  img_path = 'morph/content/temp_morphed_images/' + filename
+  os.remove(img_path)
+
 def getImages():
   dir_path = os.path.dirname(os.path.realpath(__file__)) + '/images'
   adele_low_res = skio.imread(dir_path + '/adele_2.jpg')


### PR DESCRIPTION
https://github.com/osamja/ImageMorpher/issues/1

~~Current issue is that when the morph sequence starts,, the input images have already been deleted by the regular morph

One workaround could be to mark these files for deletion and then have a cron job handle that~~

Since the morph sequence is now the default behavior, the above is no longer an issue.

As a user, once I generate a morph sequence, only the GIF file should remain.  All JPGs should be deleted.  In a follow-up PR, a cron tab will be added to automate GIFs older than a certain time period (e.g. 30 days).  In another follow-up PR, users will be asked to save the GIF locally or delete it.  This immediate decision will allow the CRON tab to run more frequently.