### PR TITLE
Copy files into face morpher image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,6 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 WORKDIR /app
 
-COPY requirements.txt .
-
 # this command was primarily copied for cmake thats necessary for dlib
 RUN apt-get update && apt-get install -y \
     cmake \
@@ -54,6 +52,7 @@ RUN apt-get update && apt-get install -y \
     libavformat-dev \
     libboost-all-dev \
     libgtk2.0-dev \
+    libgl1-mesa-glx \
     libjpeg-dev \
     liblapack-dev \
     libswscale-dev \
@@ -65,8 +64,13 @@ RUN apt-get update && apt-get install -y \
     zip \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# create imagemorpher directory in /app
+RUN mkdir imagemorpher
+COPY imagemorpher ./imagemorpher
+COPY requirements.txt .
+
+RUN mkdir imagemorpher/morph/content/temp_morphed_images
+
 RUN pip install -r requirements.txt
 
 ENV PORT_NUM=8088
-
-


### PR DESCRIPTION
With all files copied into the face morpher image, it is no longer necessary to mount the volume for the morpher to function.  Everything can be done within the image and container.  

With https://github.com/osamja/nginx_sammyjaved_proxy/commit/f6f1db2eb9975297e20efbe20a8131bedbf83669, a docker volume has been created to share the temp morphed images between nginx and the face morpher